### PR TITLE
RUN in one layer to reduce disk use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,16 @@
 FROM zzrot/alpine-node
 
-RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-# Dev install for build.
-COPY package.json /usr/src/app/package.json
-RUN npm install
+# Dev install, build, production install, and clean.
 COPY . /usr/src/app
-RUN npm run build
-
-# Production modules only.
-RUN rm -rf node_modules
-ENV NODE_ENV production
-RUN npm install
+RUN npm install \
+ && npm run build \
+ && rm -rf node_modules \
+ && npm install \
+ && rm -rf ~/.npm
 
 EXPOSE 3000
-
+ENV NODE_ENV production
 CMD [ "npm", "start"]
+


### PR DESCRIPTION
Docker's layered file system means the `RUN rm -rf node_modules` in 0425d10 will not actually reduce your disk use. You've got to put all RUN commands in a single statement. 
The RUN command structure follows: https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run 

This PR creates less layers, saving 3MB. I added `rm -rf ~/.npm` to get another 12MB.

**Before**: The data from the original `node install` is still in the `1cae88f535ba` layer
```
$ docker image history gcg
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
afe1e0b4a10c        2 minutes ago       /bin/sh -c #(nop)  CMD ["npm" "start"]          0 B                 
ae868226e58d        2 minutes ago       /bin/sh -c #(nop)  EXPOSE 3000/tcp              0 B                 
9785207d3ddf        2 minutes ago       /bin/sh -c npm install                          3.02 MB             
8d9023b407b7        2 minutes ago       /bin/sh -c #(nop)  ENV NODE_ENV=production      0 B                 
3d56d185aa79        2 minutes ago       /bin/sh -c rm -rf node_modules                  0 B                 
ff70f7df4774        2 minutes ago       /bin/sh -c npm run build                        9.39 kB             
aa6285597e4f        2 minutes ago       /bin/sh -c #(nop) COPY dir:d4c38682dc7b17e...   44.3 kB             
1cae88f535ba        2 minutes ago       /bin/sh -c npm install                          22.4 MB             
28a0a256a4ee        3 minutes ago       /bin/sh -c #(nop) COPY file:b81722d739e394...   677 B               
8800bc6f04a5        3 minutes ago       /bin/sh -c #(nop) WORKDIR /usr/src/app          0 B                 
3298c17e38c8        3 minutes ago       /bin/sh -c mkdir -p /usr/src/app                0 B                 
24bfe70a1361        7 months ago        /bin/sh -c apk add --no-cache nodejs            27.8 MB             
<missing>           7 months ago        /bin/sh -c #(nop)  MAINTAINER ZZROT LLC <d...   0 B                 
<missing>           9 months ago        /bin/sh -c #(nop) ADD file:5300ce254c0bf1d...   4.8 MB  
```

**After**:
```
$ docker history gcg-edit
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
abafdd30e718        2 minutes ago       /bin/sh -c #(nop)  CMD ["npm" "start"]          0 B                 
a1b848f1fcc6        2 minutes ago       /bin/sh -c #(nop)  ENV NODE_ENV=production      0 B                 
8d31d00bb757        2 minutes ago       /bin/sh -c #(nop)  EXPOSE 3000/tcp              0 B                 
3ad76ea7d663        2 minutes ago       /bin/sh -c npm install  && npm run build  ...   10.7 MB             
3060678434be        3 minutes ago       /bin/sh -c #(nop) COPY dir:f78b1c910b1e8bf...   47.1 kB             
9a44e39f4d2e        51 minutes ago      /bin/sh -c #(nop) WORKDIR /usr/src/app          0 B                 
24bfe70a1361        7 months ago        /bin/sh -c apk add --no-cache nodejs            27.8 MB             
<missing>           7 months ago        /bin/sh -c #(nop)  MAINTAINER ZZROT LLC <d...   0 B                 
<missing>           9 months ago        /bin/sh -c #(nop) ADD file:5300ce254c0bf1d...   4.8 MB  

$ docker images
REPOSITORY               TAG                 IMAGE ID            CREATED              SIZE
gcg-edit                 latest              abafdd30e718        About a minute ago   43.3 MB
gcg                      latest              afe1e0b4a10c        About an hour ago    58.1 MB
```
