### PR TITLE
use multi-stage feature to minimize final image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,21 @@
+# Static files stage.
 FROM zzrot/alpine-node
-
-RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-# Dev install for build.
 COPY package.json /usr/src/app/package.json
 RUN npm install
 COPY . /usr/src/app
 RUN npm run build
 
-# Production modules only.
-RUN rm -rf node_modules
-ENV NODE_ENV production
-RUN npm install
+# Production modules stage.
+FROM zzrot/alpine-node
+WORKDIR /usr/src/app
+
+COPY package.json /usr/src/app/package.json
+RUN npm install --production
+COPY . /usr/src/app
+
+COPY --from=0 /usr/src/app/dist /usr/src/app/
 
 EXPOSE 3000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY package.json /usr/src/app/package.json
 RUN npm install --production
 COPY . /usr/src/app
 
-COPY --from=0 /usr/src/app/dist /usr/src/app/
+COPY --from=0 /usr/src/app/dist/ /usr/src/app/dist/
 
 EXPOSE 3000
 


### PR DESCRIPTION
The development npm modules are not installed in the final image, the static files are copied over.